### PR TITLE
Added import datetime in codebase

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,5 @@
 import base64
+import datetime
 import streamlit as st
 import plotly.express as px
 import pandas as pd


### PR DESCRIPTION
Added import datetime in codebase to resolve error message: NameError: name 'datetime' is not defined.
Issue:  https://github.com/Amna-Hassan04/Serenity-Guide/issues/50

![screenshot pr import datetime](https://github.com/user-attachments/assets/bca773e3-1adb-4a5e-bfca-180fece100cd)
